### PR TITLE
[80X] update the pA simulation GT to take latest L1T menu and HLT JECs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -20,7 +20,7 @@ autoCond = {
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '80X_mcRun2_HeavyIon_v12',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '80X_mcRun2_pA_v1',
+    'run2_mc_pa'        :   '80X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '80X_dataRun2_Candidate_2016_09_02_10_26_48',
     # GlobalTag for Run2 data reprocessing


### PR DESCRIPTION
# Summary of changes in Global Tags 
 
## RunII simulation 
 
   * **RunII Proton-Lead scenario** : [80X_mcRun2_pA_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_pA_v2) as [80X_mcRun2_pA_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_mcRun2_pA_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_mcRun2_pA_v2/80X_mcRun2_pA_v1): 
      * Updated L1 menu to `L1Menu_HeavyIons2016_v3_m2_xml` 
      * Updated HLT Jet Energy Corrections with new L2L3Residual step for 8 TeV pPb HLT where L1FastJet L2Relative and L3Absolute are taken from `JetCorrectorParametersCollection_HLT_BX25_V11_MC_AK4PFHLT` and `JetCorrectorParametersCollection_HLT_BX25_V11_MC_AK4CaloHLT`