### PR TITLE
customization for missing E/gamma PM parameters

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -163,6 +163,34 @@ def customiseFor18429(process):
 
      return process
 
+#add the missing parameters for E/g pixelmatching
+def customiseFor18820(process):
+    for edproducer in producers_by_type(process, "EgammaHLTFilteredSuperClusterProducer"):
+        if not hasattr(edproducer,'cuts'):
+            edproducer.cuts = cms.VPSet( 
+                cms.PSet(
+                    var = cms.InputTag("hltEgammaHoverE"),
+                    barrelCut = cms.PSet(
+                        cutOverE = cms.double(0.2),
+                        useEt = cms.bool(False)
+                        ),
+                    endcapCut = cms.PSet(
+                        cutOverE = cms.double(0.2),
+                        useEt = cms.bool(False)
+                        )
+                    )
+                )
+            if edproducer.cands.moduleLabel.find("Unseeded")!=-1:
+                edproducer.cuts[0].var=cms.InputTag("hltEgammaHoverEUnseeded")
+    
+
+    for edproducer in producers_by_type(process, "ElectronNHitSeedProducer"):
+        if not hasattr(edproducer,'superClusters'):
+            edproducer.superClusters=cms.VInputTag('hltEgammaSuperClustersToPixelMatch') 
+            if edproducer.initialSeeds.moduleLabel.find("Unseeded")!=-1:
+                edproducer.superClusters=cms.VInputTag('hltEgammaSuperClustersToPixelMatchUnseeded') 
+    return process
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
@@ -176,6 +204,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
         process = customiseFor18559(process)
 
     # add call to action function in proper order: newest last!
-    # process = customiseFor12718(process)
-
+    # process = customiseFor12718(process
+        process = customiseFor18820(process)
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -205,5 +205,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process
-        process = customiseFor18820(process)
+    process = customiseFor18820(process)
+    
     return process


### PR DESCRIPTION
Dear Storm,

Here is the customisation function to be able to run the E/g PM matching with the 9_1_0 confdb parse. Again my appologies for the extra work I caused you here. Please let me know how you wish  to proceed. 


