### PR TITLE
added 3 more 2025 L1T seeds to `customizeHLTfor2024L1TMenu`

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTfor2025Studies.py
+++ b/HLTrigger/Configuration/python/customizeHLTfor2025Studies.py
@@ -85,6 +85,10 @@ def customizeHLTfor2024L1TMenu(process):
         'L1_DoubleEG16_11_er1p2_dR_Max0p6': 'L1_DoubleEG11_er1p2_dR_Max0p6',
         'L1_DoubleEG17_11_er1p2_dR_Max0p6': 'L1_DoubleEG11_er1p2_dR_Max0p6',
 
+        'L1_DoubleEG15_er1p5_dEta_Max1p5': 'L1_AlwaysTrue',
+        'L1_DoubleEG16_er1p5_dEta_Max1p5': 'L1_AlwaysTrue',
+        'L1_DoubleEG17_er1p5_dEta_Max1p5': 'L1_AlwaysTrue',
+
         'L1_DoubleJet_110_35_DoubleJet35_Mass_Min1000': 'L1_AlwaysTrue',
         'L1_DoubleJet_110_35_DoubleJet35_Mass_Min1100': 'L1_AlwaysTrue',
         'L1_DoubleJet_110_35_DoubleJet35_Mass_Min1200': 'L1_AlwaysTrue',


### PR DESCRIPTION
Added three 2025 L1T seeds to `customizeHLTfor2024L1TMenu`.
 - I initially forgot them, and they are not currently used in any `GRun` menus, but they might be introduced in an upcoming ticket (see [here](https://indico.cern.ch/event/1527099/#34-exo-low-pt-doubleeg-trigger)). Since they have no obvious counterpart in the 2024 menu, they are replaced with a placeholder seed (`L1_AlwaysTrue`).
 - Tested this change using the example in the [GlobalHLT twiki](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideGlobalHLT#CMSSW_15_0_X_with_customizations).
 -  The customisation function should now include all the new L1T seeds that we expect to use at HLT (the other ones are only L1T "monitoring" seeds).