### PR TITLE
update `customizeHLTfor2025Studies` with first candidate HLT JECs for 2025

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTfor2025Studies.py
+++ b/HLTrigger/Configuration/python/customizeHLTfor2025Studies.py
@@ -36,10 +36,10 @@ def customizeHLTforCMSHLT3469(process):
 
 def customizeHLTfor2025JECs(process):
     jecTagsDict = {
-        'AK4CaloHLT': '', # not available yet
-        'AK8CaloHLT': '', # not available yet
-        'AK4PFHLT': '', # not available yet
-        'AK8PFHLT': '', # not available yet
+        'AK4CaloHLT': 'JetCorrectorParametersCollection_Run3Winter25Digi_AK4CaloHLT_v1',
+        'AK8CaloHLT': 'JetCorrectorParametersCollection_Run3Winter25Digi_AK8CaloHLT_v1',
+        'AK4PFHLT': 'JetCorrectorParametersCollection_Run3Winter25Digi_AK4PFHLT_v1',
+        'AK8PFHLT': 'JetCorrectorParametersCollection_Run3Winter25Digi_AK8PFHLT_v1',
     }
 
     try:
@@ -59,8 +59,8 @@ def customizeHLTfor2025JECs(process):
 def customizeHLTfor2025Studies(process):
     process = customizeHLTfor2025HCALPFCuts(process)
     process = customizeHLTfor2025PFHadronCalibrations(process)
-#    process = customizeHLTforCMSHLT3469(process)
-#    process = customizeHLTfor2025JECs(process)
+    process = customizeHLTforCMSHLT3469(process)
+    process = customizeHLTfor2025JECs(process)
     return process
 
 def customizeHLTfor2024L1TMenu(process):


### PR DESCRIPTION
Updating one of the customisation functions for 2025, in order for STEAM to check the HLT rates with the latest candidate HLT JECs for 2025.
 - Tested this change using the example in the [GlobalHLT twiki](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideGlobalHLT#CMSSW_15_0_X_with_customizations).
