### PR TITLE
update `customizeHLTfor2025Studies` with "V2" of 2025 HLT JECs (and add a customisation for "V1" JECs)

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTfor2025Studies.py
+++ b/HLTrigger/Configuration/python/customizeHLTfor2025Studies.py
@@ -34,7 +34,7 @@ def customizeHLTforCMSHLT3469(process):
         prod.EcalRecHitThresh = True
     return process
 
-def customizeHLTfor2025JECs(process):
+def customizeHLTfor2025JECsV1(process):
     jecTagsDict = {
         'AK4CaloHLT': 'JetCorrectorParametersCollection_Run3Winter25Digi_AK4CaloHLT_v1',
         'AK8CaloHLT': 'JetCorrectorParametersCollection_Run3Winter25Digi_AK8CaloHLT_v1',
@@ -52,8 +52,37 @@ def customizeHLTfor2025JECs(process):
                 ),
             ]
     except:
+        raise RuntimeError("customizeHLTfor2025JECsV1 -- GlobalTag ESSource could not be customized !")
+
+    return process
+
+def customizeHLTfor2025JECs(process):
+    jecTagsDict = {
+        'AK4CaloHLT': 'JetCorrectorParametersCollection_Run3Winter25Digi_AK4CaloHLT_v2',
+        'AK8CaloHLT': 'JetCorrectorParametersCollection_Run3Winter25Digi_AK8CaloHLT_v2',
+        'AK4PFHLT': 'JetCorrectorParametersCollection_Run3Winter25Digi_AK4PFHLT_v2',
+        'AK8PFHLT': 'JetCorrectorParametersCollection_Run3Winter25Digi_AK8PFHLT_v2',
+    }
+
+    try:
+        for (labelName, tagName) in jecTagsDict.items():
+            process.GlobalTag.toGet += [
+                cms.PSet(
+                    record = cms.string("JetCorrectionsRecord"),
+                    label = cms.untracked.string(labelName),
+                    tag = cms.string(tagName),
+                ),
+            ]
+    except:
         raise RuntimeError("customizeHLTfor2025JECs -- GlobalTag ESSource could not be customized !")
 
+    return process
+
+def customizeHLTfor2025Studies_JECsV1(process):
+    process = customizeHLTfor2025HCALPFCuts(process)
+    process = customizeHLTfor2025PFHadronCalibrations(process)
+    process = customizeHLTforCMSHLT3469(process)
+    process = customizeHLTfor2025JECsV1(process)
     return process
 
 def customizeHLTfor2025Studies(process):


### PR DESCRIPTION
Updating the main customisation function for 2025 conditions, in order to use the latest HLT JECs ("V2") provided by the JME POG (see TSG meeting on Apr-23, and [CMSHLT-3516](https://its.cern.ch/jira/browse/CMSHLT-3516)).

In addition, a version of the same customisation function using the previous set of JECs ("V1") is added, in case it's needed for further studies.

Tested this change using the example in the [GlobalHLT twiki](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideGlobalHLT#CMSSW_15_0_X_with_customizations) (incl. a similar check for the "V1" customisation function).
