### PR TITLE
Including new seeds of 2025-v1_1_1 L1T menu in `customizeHLTfor2024L1TMenu`

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTfor2025Studies.py
+++ b/HLTrigger/Configuration/python/customizeHLTfor2025Studies.py
@@ -110,6 +110,10 @@ def customizeHLTfor2024L1TMenu(process):
         'L1_DoubleTau_Iso38_Iso26_er2p1_Jet55_RmOvlp_dR0p5': 'L1_DoubleIsoTau26er2p1_Jet55_RmOvlp_dR0p5 OR L1_DoubleIsoTau26er2p1_Jet70_RmOvlp_dR0p5',
         'L1_DoubleTau_Iso40_Iso26_er2p1_Jet55_RmOvlp_dR0p5': 'L1_DoubleIsoTau26er2p1_Jet55_RmOvlp_dR0p5 OR L1_DoubleIsoTau26er2p1_Jet70_RmOvlp_dR0p5',
 
+        'L1_DoubleTau_Iso34_Iso23_er2p1_Jet55_RmOvlp_dR0p5': 'L1_DoubleIsoTau26er2p1_Jet55_RmOvlp_dR0p5 OR L1_DoubleIsoTau26er2p1_Jet70_RmOvlp_dR0p5',
+        'L1_DoubleTau_Iso34_Iso23_er2p1_Jet70_RmOvlp_dR0p5': 'L1_DoubleIsoTau26er2p1_Jet55_RmOvlp_dR0p5 OR L1_DoubleIsoTau26er2p1_Jet70_RmOvlp_dR0p5',
+        'L1_DoubleTau_Iso34_Iso26_er2p1_Jet70_RmOvlp_dR0p5': 'L1_DoubleIsoTau26er2p1_Jet55_RmOvlp_dR0p5 OR L1_DoubleIsoTau26er2p1_Jet70_RmOvlp_dR0p5',
+
         'L1_DoubleEG15_11_er1p2_dR_Max0p6': 'L1_DoubleEG11_er1p2_dR_Max0p6',
         'L1_DoubleEG16_11_er1p2_dR_Max0p6': 'L1_DoubleEG11_er1p2_dR_Max0p6',
         'L1_DoubleEG17_11_er1p2_dR_Max0p6': 'L1_DoubleEG11_er1p2_dR_Max0p6',


### PR DESCRIPTION
Simply extending the function `customizeHLTfor2024L1TMenu`  to take into account the new seeds included in the latest 2025 L1T menu [[1]](https://github.com/cms-l1-dpg/L1MenuRun3/tree/e9cc86fdc443871681085a28fd2bf62ac1261674/development/L1Menu_Collisions2025_v1_1_1) [[2]](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/tags/L1Menu_Collisions2025_v1_1_1_xml).
 - Tested this change using the example in the [GlobalHLT twiki](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideGlobalHLT#CMSSW_15_0_X_with_customizations).
